### PR TITLE
Add command line argument parsing

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -5,7 +5,6 @@
 
 #define BUILD_DIR "build"
 #define TEST_DIR "tests"
-
 #define SOURCES "src/log.c", "src/frontend/lexer.c", "src/arena.c", "src/frontend/parser.c", "src/backend/ir.c", "src/backend/codegen/nasm_x86_64_linux.c", "src/util.c"
 
 #ifdef _WIN32
@@ -94,4 +93,4 @@ bool run_tests() {
     return true;
 }
 
-void common_flags(Cmd *cmd) { cmd_append(cmd, "-Wall", "-Wextra", "-Werror", "-std=c17", "-O3", "-g"); }
+void common_flags(Cmd *cmd) { cmd_append(cmd, "-Wall", "-Wextra", "-Werror", "-std=c17", "-O3", "-g", "-Wno-nonnull", "-Wno-format-overflow" ); }

--- a/src/main.c
+++ b/src/main.c
@@ -6,35 +6,32 @@
 #include "frontend/lexer.h"
 #include "frontend/parser.h"
 
-#include "backend/ir.h"
 #include "backend/codegen/nasm_x86_64_linux.h"
-
-#include <errno.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+#include "backend/ir.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 static void usage(char *program_name);
 
+typedef struct {
+    char *exe_name;
+    char *input_name;
+    char *output_name;
+    bool keep_build_artifacts;
+} Config;
+
+bool parse_config(Config *conf, int argc, char **argv);
 
 int main(int argc, char **argv) {
-    // TODO: Unhardcode the argument parsing
-    char *program_name = argv[0];
-    if (argc < 3) {
-        usage(program_name);
+    Config c = {0};
+    if (!parse_config(&c, argc, argv)) {
+        usage(c.exe_name);
         return 1;
     }
-    char *input_name = argv[1];
-    char *output_name = argv[2];
 
     SourceFile file = {0};
-    if (!read_source_file(input_name, &file)) return 1;
+    if (!read_source_file(c.input_name, &file)) return 1;
     Lexer l = {.begin_of_src = file.src.items, .file = FILE_VIEW_FROM_FILE(file)};
     Tokens tokens = {0};
 
@@ -62,27 +59,95 @@ int main(int argc, char **argv) {
     if (!generate_ir_module(&tree, &mod)) return 1;
 
     // TODO: Do something to this mess
-    size_t output_name_len = strlen(output_name);
+    size_t output_name_len = strlen(c.output_name);
     size_t output_asm_name_len = output_name_len + 4;
-    char* out_asm_name = malloc((output_asm_name_len + 1) * sizeof(char));
+    char *out_asm_name = malloc((output_asm_name_len + 1) * sizeof(char));
     out_asm_name[output_asm_name_len] = 0;
-    sprintf(out_asm_name, "%s.asm", output_name);
+    sprintf(out_asm_name, "%s.asm", c.output_name);
 
     size_t output_o_name_len = output_name_len + 4;
-    char* out_o_name = malloc((output_o_name_len + 1) * sizeof(char));
+    char *out_o_name = malloc((output_o_name_len + 1) * sizeof(char));
     out_o_name[output_o_name_len] = 0;
-    sprintf(out_o_name, "%s.o", output_name);
+    sprintf(out_o_name, "%s.o", c.output_name);
 
-    FILE* asm_file = fopen(out_asm_name, "wb");
+    FILE *asm_file = fopen(out_asm_name, "wb");
     nasm_x86_64_linux_generate_file(asm_file, &mod);
     fclose(asm_file);
 
-    run_program("nasm", (char*[]){"nasm", out_asm_name, "-f", "elf64", "-o", out_o_name, NULL});
-    run_program("ld", (char*[]){"ld", out_o_name, "-o", output_name, NULL});
+    if (run_program("nasm", (char *[]){"nasm", out_asm_name, "-f", "elf64", "-o", out_o_name, NULL}) != 0) {
+        log_diagnostic(LL_ERROR, "nasm failed");
+        return 1;
+    }
+    if (run_program("ld", (char *[]){"ld", out_o_name, "-o", c.output_name, NULL}) != 0) {
+        if (c.keep_build_artifacts) { run_program("rm", (char *[]){"rm", out_o_name, out_asm_name, NULL}); }
+        log_diagnostic(LL_ERROR, "ld failed");
+        return 1;
+    }
+    if (c.keep_build_artifacts) { run_program("rm", (char *[]){"rm", out_o_name, out_asm_name, NULL}); }
 }
 
+bool parse_config(Config *conf, int argc, char **argv) {
+    conf->exe_name = *argv;
+    argc--;
+    argv++;
+
+    while (argc > 0) {
+        if (strcmp(*argv, "-o") == 0) {
+            if (conf->output_name != NULL) {
+                log_diagnostic(LL_ERROR, "Found a duplicate output file name flag");
+                return false;
+            }
+            argc--;
+            argv++;
+            if (argc >= 0) {
+                log_diagnostic(LL_ERROR, "Expected a file name to be here to set a custom output file");
+                return false;
+            }
+            conf->output_name = *argv;
+            argc--;
+            argv++;
+        } else if (strcmp(*argv, "-keep-artifacts") == 0) {
+            conf->keep_build_artifacts = true;
+            argc--;
+            argv++;
+        } else if (strcmp(*argv, "-help")) {
+            usage(conf->exe_name);
+            exit(0);
+        } else {
+            if (**argv == '-') {
+                log_diagnostic(LL_ERROR, "Unknown flag supplied");
+                return false;
+            }
+            if (conf->input_name != NULL) {
+                log_diagnostic(LL_ERROR, "Compiling multiple files at the same time is not supported");
+                return false;
+            }
+            conf->input_name = *argv;
+            argc--;
+            argv++;
+        }
+    }
+
+    if (conf->input_name == NULL) {
+        log_diagnostic(LL_ERROR, "No input name is provided");
+        return false;
+    }
+
+    if (conf->output_name == NULL) {
+        size_t len = strlen(conf->input_name) - 3;
+        conf->output_name = malloc(sizeof(char) * (len + 1));
+        conf->output_name[len] = 0;
+        snprintf(conf->output_name, len, "%s", conf->input_name);
+    }
+
+    return true;
+}
 
 static void usage(char *program_name) {
-    log_message(LL_INFO, "Usage: ");
-    log_message(LL_INFO, "  %s <input.boa> <output-name>", program_name);
+    log_diagnostic(LL_INFO, "Usage: ");
+    log_diagnostic(LL_INFO, "  %s <input.boa> [FLAGS]", program_name);
+    log_diagnostic(LL_INFO, "  [FLAGS]:");
+    log_diagnostic(LL_INFO, "    -help : show this help message");
+    log_diagnostic(LL_INFO, "    -o : Customize the output file name (format: -o <name>)");
+    log_diagnostic(LL_INFO, "    -keep-artifacts : Keep the build artifacts (.asm, .o files)");
 }


### PR DESCRIPTION
Add arg parsing.
Flags added:
 - `-o` customize output exe name
 - `-keep-artifacts` optional argument to keep .asm and .o files that are emitted during build time
 - `-help` help info print command