### PR TITLE
Windows target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Yeah so I'm making another language :DD
 
 ## Build
 ```bash
- $ gcc nob.c -o nob
- $ ./nob
- $ ./build/boa -help
+  gcc nob.c -o nob
+  ./nob
+  ./build/boa -help
 ```
 
 ## Supported targets
- - Windows (via mingw)
- - Linux (via nasm)
+- Windows (via mingw)
+- Linux (via nasm)
 
 ## Code guidelines (be 'more formal')
  - Be as assertive as possible (via the `ASSERT` and `UNREACHABLE` macros in src/util.h)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Yeah so I'm making another language :DD
 ```bash
  $ gcc nob.c -o nob
  $ ./nob
- $ ./build/boa
+ $ ./build/boa -help
 ```
 
+## Supported targets
+ - Windows (via mingw)
+ - Linux (via nasm)
 
 ## Code guidelines (be 'more formal')
  - Be as assertive as possible (via the `ASSERT` and `UNREACHABLE` macros in src/util.h)

--- a/nob.c
+++ b/nob.c
@@ -7,7 +7,7 @@
 
 #define BUILD_DIR "build"
 #define TEST_DIR "tests"
-#define SOURCES "src/log.c", "src/frontend/lexer.c", "src/arena.c", "src/frontend/parser.c", "src/backend/ir/ssa.c", "src/backend/codegen/nasm_x86_64_linux.c", "src/util.c", "src/config.c", "src/target.c"
+#define SOURCES "src/log.c", "src/frontend/lexer.c", "src/arena.c", "src/frontend/parser.c", "src/backend/ir/ssa.c", "src/backend/codegen/nasm_x86_64_linux.c", "src/util.c", "src/config.c", "src/target.c", "src/backend/codegen/mingw_x86_64_windows.c"
 
 // #ifdef _WIN32
 //     @sa.pohod ty <3

--- a/nob.c
+++ b/nob.c
@@ -7,7 +7,7 @@
 
 #define BUILD_DIR "build"
 #define TEST_DIR "tests"
-#define SOURCES "src/log.c", "src/frontend/lexer.c", "src/arena.c", "src/frontend/parser.c", "src/backend/ir/ssa.c", "src/backend/codegen/nasm_x86_64_linux.c", "src/util.c", "src/config.c"
+#define SOURCES "src/log.c", "src/frontend/lexer.c", "src/arena.c", "src/frontend/parser.c", "src/backend/ir/ssa.c", "src/backend/codegen/nasm_x86_64_linux.c", "src/util.c", "src/config.c", "src/target.c"
 
 // #ifdef _WIN32
 //     @sa.pohod ty <3

--- a/src/backend/codegen/mingw_x86_64_windows.c
+++ b/src/backend/codegen/mingw_x86_64_windows.c
@@ -33,7 +33,7 @@ bool mingw_x86_64_windows_generate_file(FILE *sink, const SSAModule *mod) {
     fprintf(sink, "_start:\n");
     fprintf(sink, "   call main\n");
     fprintf(sink, "   mov rcx, rax\n");
-    fprintf(sink, "   sub rsp, 8\n");
+    fprintf(sink, "   sub rsp, 40\n");
     fprintf(sink, "   call ExitProcess\n");
 
     generate_function(sink, &mod->functions.items[0]);

--- a/src/backend/codegen/mingw_x86_64_windows.c
+++ b/src/backend/codegen/mingw_x86_64_windows.c
@@ -90,7 +90,6 @@ static bool generate_statement(FILE *sink, const SSAStatement *st) {
     return true;
 }
 
-
 static void emit_return_some(FILE *sink, const SSAStatement *ret) {
     ASSERT(ret->type == SSAST_RETURN,
            "This function should only be called when the type of the statement is SSAST_RETURN");
@@ -198,4 +197,3 @@ static void value_asm_repr(FILE *sink, const SSAValue *value) {
     }
     }
 }
-

--- a/src/backend/codegen/mingw_x86_64_windows.c
+++ b/src/backend/codegen/mingw_x86_64_windows.c
@@ -2,17 +2,200 @@
 #include "../../util.h"
 #include <stdio.h>
 
-bool mingw_x86_64_windows_generate_file(FILE* sink, const SSAModule* mod) {
+static bool generate_function(FILE *sink, const SSAFunction *func);
+static bool generate_statement(FILE *sink, const SSAStatement *st);
+
+static void emit_return_some(FILE *sink, const SSAStatement *ret);
+static void emit_return_none(FILE *sink, const SSAStatement *ret_none);
+
+static void emit_add(FILE *sink, const SSAStatement *st);
+static void emit_sub(FILE *sink, const SSAStatement *st);
+static void emit_imul(FILE *sink, const SSAStatement *st);
+static void emit_div(FILE *sink, const SSAStatement *st);
+static void emit_assign(FILE *sink, const SSAStatement *st);
+
+static void emit_add_reg_value(FILE *sink, const char *reg, const SSAValue *value);
+static void emit_sub_reg_value(FILE *sink, const char *reg, const SSAValue *value);
+static void emit_imul_reg_value(FILE *sink, const char *reg, const SSAValue *value);
+static void move_value_into_register(FILE *sink, const char *reg, const SSAValue *value);
+static void move_value_into_value(FILE *sink, const SSAValue *from, const SSAValue *into);
+
+static void value_asm_repr(FILE *sink, const SSAValue *value);
+
+bool mingw_x86_64_windows_generate_file(FILE *sink, const SSAModule *mod) {
     ASSERT(mod->functions.count == 1, "expect only one function for now");
     ASSERT(strcmp(mod->functions.items[0].name, "main") == 0, "expect only a main function");
-    
+
     fprintf(sink, ".intel_syntax noprefix\n");
     fprintf(sink, ".extern ExitProcess\n");
     fprintf(sink, ".global _start\n");
     fprintf(sink, ".section .text\n");
     fprintf(sink, "_start:\n");
-    fprintf(sink, "   mov rcx, 69\n");
+    fprintf(sink, "   call main\n");
+    fprintf(sink, "   mov rcx, rax\n");
     fprintf(sink, "   sub rsp, 8\n");
     fprintf(sink, "   call ExitProcess\n");
+
+    generate_function(sink, &mod->functions.items[0]);
+
     return true;
 }
+
+static bool generate_function(FILE *sink, const SSAFunction *func) {
+    fprintf(sink, "%s:\n", func->name);
+    fprintf(sink, "  enter %ld, 0\n", func->max_temps * 8);
+
+    for (size_t i = 0; i < func->body.count; i++) { generate_statement(sink, &func->body.items[i]); }
+
+    fprintf(sink, "ret:\n");
+    fprintf(sink, "  leave\n");
+    fprintf(sink, "  ret\n");
+
+    return true;
+}
+static bool generate_statement(FILE *sink, const SSAStatement *st) {
+
+    switch (st->type) {
+    case SSAST_RETURN: {
+        emit_return_some(sink, st);
+        return true;
+    }
+    case SSAST_RETURN_EMPTY: {
+        emit_return_none(sink, st);
+        return true;
+    }
+    case SSAST_ADD: {
+        emit_add(sink, st);
+        return true;
+    }
+    case SSAST_SUB: {
+        emit_sub(sink, st);
+        return true;
+    }
+    case SSAST_MUL: {
+        emit_imul(sink, st);
+        return true;
+    }
+    case SSAST_DIV: {
+        emit_div(sink, st);
+        return true;
+    }
+    case SSAST_ASSIGN: {
+        emit_assign(sink, st);
+        return true;
+    }
+    default: TODO();
+    }
+
+    return true;
+}
+
+
+static void emit_return_some(FILE *sink, const SSAStatement *ret) {
+    ASSERT(ret->type == SSAST_RETURN,
+           "This function should only be called when the type of the statement is SSAST_RETURN");
+    move_value_into_register(sink, "rax", &ret->ret.value);
+    fprintf(sink, "  jmp ret\n");
+}
+
+static void emit_return_none(FILE *sink, const SSAStatement *ret_none) {
+    ASSERT(ret_none->type == SSAST_RETURN_EMPTY,
+           "This function should only be called when the type of the statement is SSAST_RETURN_EMPTY");
+    fprintf(sink, "  jmp ret\n");
+}
+
+static void emit_add(FILE *sink, const SSAStatement *st) {
+    ASSERT(st->type == SSAST_ADD, "This function should only be called when the type of the statement is SSAST_ADD");
+    ASSERT(st->binop.result.type == SSAVT_TEMP, "we can't add to a constant");
+    move_value_into_register(sink, "rax", &st->binop.l);
+
+    emit_add_reg_value(sink, "rax", &st->binop.r);
+    fprintf(sink, "  mov qword [rbp - %ld], rax\n", (st->binop.result.temp + 1) * 8);
+}
+
+static void emit_sub(FILE *sink, const SSAStatement *st) {
+    ASSERT(st->type == SSAST_SUB, "This function should only be called when the type of the statement is SSAST_SUB");
+    ASSERT(st->binop.result.type == SSAVT_TEMP, "we can't sub a constant");
+    move_value_into_register(sink, "rax", &st->binop.l);
+
+    emit_sub_reg_value(sink, "rax", &st->binop.r);
+    fprintf(sink, "  mov qword [rbp - %ld], rax\n", (st->binop.result.temp + 1) * 8);
+}
+
+static void emit_imul(FILE *sink, const SSAStatement *st) {
+    ASSERT(st->type == SSAST_MUL, "This function should only be called when the type of the statement is SSAST_MUL");
+    ASSERT(st->binop.result.type == SSAVT_TEMP, "we can't mul a constant");
+    move_value_into_register(sink, "rax", &st->binop.l);
+
+    emit_imul_reg_value(sink, "rax", &st->binop.r);
+    fprintf(sink, "  mov qword [rbp - %ld], rax\n", (st->binop.result.temp + 1) * 8);
+}
+
+static void emit_div(FILE *sink, const SSAStatement *st) {
+    // ugh x86_64 is so weird
+    // rax low bits
+    // rdi high bits
+    ASSERT(st->type == SSAST_DIV, "This function should only be called when the type of the statement is SSAST_DIV");
+    ASSERT(st->binop.result.type == SSAVT_TEMP, "we can't div a constant");
+    move_value_into_register(sink, "rax", &st->binop.l);
+    fprintf(sink, "  xor rdx, rdx\n");
+    move_value_into_register(sink, "rcx", &st->binop.r);
+    fprintf(sink, "  div rcx\n");
+    fprintf(sink, "  mov qword [rbp - %ld], rax\n", (st->binop.result.temp + 1) * 8);
+}
+
+static void emit_assign(FILE *sink, const SSAStatement *st) {
+    ASSERT(st->type == SSAST_ASSIGN,
+           "This function should only be called when the type of the statement is SSAST_ASSIGN");
+
+    SSAValue temp_value = {.temp = st->assign.place, .type = SSAVT_TEMP};
+    move_value_into_value(sink, &st->assign.value, &temp_value);
+}
+
+static void move_value_into_value(FILE *sink, const SSAValue *from, const SSAValue *into) {
+    // Load source into a register
+    move_value_into_register(sink, "rax", from);
+
+    // Store register into destination
+    fprintf(sink, "  mov ");
+    value_asm_repr(sink, into);
+    fprintf(sink, ", rax\n");
+}
+
+static void emit_add_reg_value(FILE *sink, const char *reg, const SSAValue *value) {
+    fprintf(sink, "  add %s, ", reg);
+    value_asm_repr(sink, value);
+    fprintf(sink, "\n");
+}
+
+static void emit_sub_reg_value(FILE *sink, const char *reg, const SSAValue *value) {
+    fprintf(sink, "  sub %s, ", reg);
+    value_asm_repr(sink, value);
+    fprintf(sink, "\n");
+}
+
+static void emit_imul_reg_value(FILE *sink, const char *reg, const SSAValue *value) {
+    fprintf(sink, "  imul %s, ", reg);
+    value_asm_repr(sink, value);
+    fprintf(sink, "\n");
+}
+
+static void move_value_into_register(FILE *sink, const char *reg, const SSAValue *value) {
+    fprintf(sink, "  mov %s, ", reg);
+    value_asm_repr(sink, value);
+    fprintf(sink, "\n");
+}
+
+static void value_asm_repr(FILE *sink, const SSAValue *value) {
+    switch (value->type) {
+    case SSAVT_CONST: {
+        fprintf(sink, "%ld", value->constant);
+        break;
+    }
+    case SSAVT_TEMP: {
+        fprintf(sink, "qword [rbp - %ld]", (value->temp + 1) * 8);
+        break;
+    }
+    }
+}
+

--- a/src/backend/codegen/mingw_x86_64_windows.c
+++ b/src/backend/codegen/mingw_x86_64_windows.c
@@ -1,0 +1,18 @@
+#include "mingw_x86_64_windows.h"
+#include "../../util.h"
+#include <stdio.h>
+
+bool mingw_x86_64_windows_generate_file(FILE* sink, const SSAModule* mod) {
+    ASSERT(mod->functions.count == 1, "expect only one function for now");
+    ASSERT(strcmp(mod->functions.items[0].name, "main") == 0, "expect only a main function");
+    
+    fprintf(sink, ".intel_syntax noprefix\n");
+    fprintf(sink, ".extern ExitProcess\n");
+    fprintf(sink, ".global _start\n");
+    fprintf(sink, ".section .text\n");
+    fprintf(sink, "_start:\n");
+    fprintf(sink, "   mov rcx, 69\n");
+    fprintf(sink, "   sub rsp, 8\n");
+    fprintf(sink, "   call ExitProcess\n");
+    return true;
+}

--- a/src/backend/codegen/mingw_x86_64_windows.h
+++ b/src/backend/codegen/mingw_x86_64_windows.h
@@ -1,0 +1,10 @@
+
+#ifndef MINGW_X86_64_WINDOWS_H
+#define  MINGW_X86_64_WINDOWS_H
+
+#include "../ir/ssa.h"
+#include <stdio.h>
+
+bool mingw_x86_64_windows_generate_file(FILE* sink, const SSAModule* mod);
+
+#endif

--- a/src/backend/codegen/mingw_x86_64_windows.h
+++ b/src/backend/codegen/mingw_x86_64_windows.h
@@ -1,10 +1,11 @@
 
 #ifndef MINGW_X86_64_WINDOWS_H
-#define  MINGW_X86_64_WINDOWS_H
+#define MINGW_X86_64_WINDOWS_H
 
 #include "../ir/ssa.h"
+#include <stdbool.h>
 #include <stdio.h>
 
-bool mingw_x86_64_windows_generate_file(FILE* sink, const SSAModule* mod);
+bool mingw_x86_64_windows_generate_file(FILE *sink, const SSAModule *mod);
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -1,6 +1,10 @@
 #include "config.h"
 #include "log.h"
+#include "target.h"
 #include "util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 bool parse_config(Config *conf, int argc, char **argv) {
@@ -35,8 +39,9 @@ bool parse_config(Config *conf, int argc, char **argv) {
             argc--;
             argv++;
         } else if (strcmp(*argv, "-list-targets") == 0) {
-            log_diagnostic(LL_INFO, "linux_nasm");
-            log_diagnostic(LL_INFO, "windows_mingw");
+            for (TargetKind tk = 0; tk < TK_Count; tk++) {
+                log_diagnostic(LL_INFO, "%s", target_enum_to_str(tk));
+            }
             exit(0);
         } else if (strcmp(*argv, "-target") == 0) {
             argc--;
@@ -45,17 +50,12 @@ bool parse_config(Config *conf, int argc, char **argv) {
                 log_diagnostic(LL_ERROR, "Expected a target name (run %s -list-targets)", conf->exe_name);
                 return false;
             }
-            if (strcmp(*argv, "linux_nasm") == 0) {
-                conf->target = *argv;
-                argc--;
-                argv++;
-            } else if (strcmp(*argv, "windows_mingw") == 0) {
-                conf->target = *argv;
-                argc--;
-                argv++;
-            } else {
+            Target* t;
+            if (!find_target(&t, *argv)) {
                 log_diagnostic(LL_ERROR, "Unknown target name %s (run %s -list-targets)", *argv, conf->exe_name);
                 return false;
+            } else {
+                conf->target = *argv;
             }
         } else {
             if (**argv == '-') {
@@ -95,7 +95,7 @@ void usage(char *program_name) {
     log_diagnostic(LL_INFO, "    -help           : Show this help message");
     log_diagnostic(LL_INFO, "    -o              : Customize the output file name (format: -o <name>)");
     log_diagnostic(LL_INFO, "    -keep-artifacts : Keep the build artifacts (.asm, .o files)");
-    log_diagnostic(LL_INFO, "    -no-opt         : Dont optimize the code");
+    log_diagnostic(LL_INFO, "    -no-opt         : Don't optimize the code");
     log_diagnostic(LL_INFO, "    -target <TARGET>: Select the target");
     log_diagnostic(LL_INFO, "    -list-targets   : List available targets");
 }

--- a/src/config.c
+++ b/src/config.c
@@ -47,7 +47,7 @@ bool parse_config(Config *conf, int argc, char **argv) {
                 conf->target = *argv;
                 argc--;
                 argv++;
-            } else if (strcmp(*argv, "windows_mingw")) {
+            } else if (strcmp(*argv, "windows_mingw") == 0) {
                 conf->target = *argv;
                 argc--;
                 argv++;

--- a/src/config.c
+++ b/src/config.c
@@ -56,6 +56,8 @@ bool parse_config(Config *conf, int argc, char **argv) {
                 return false;
             } else {
                 conf->target = *argv;
+                argc--;
+                argv++;
             }
         } else {
             if (**argv == '-') {

--- a/src/config.c
+++ b/src/config.c
@@ -32,6 +32,8 @@ bool parse_config(Config *conf, int argc, char **argv) {
             exit(0);
         } else if (strcmp(*argv, "-no-opt") == 0) {
             conf->dont_optimize = true;
+            argc--;
+            argv++;
         } else if (strcmp(*argv, "-list-targets") == 0) {
             log_diagnostic(LL_INFO, "linux_nasm");
             log_diagnostic(LL_INFO, "windows_mingw");

--- a/src/config.c
+++ b/src/config.c
@@ -1,6 +1,7 @@
 #include "config.h"
-#include <string.h>
+#include "log.h"
 #include "util.h"
+#include <string.h>
 
 bool parse_config(Config *conf, int argc, char **argv) {
     conf->exe_name = *argv;
@@ -15,7 +16,7 @@ bool parse_config(Config *conf, int argc, char **argv) {
             }
             argc--;
             argv++;
-            if (argc >= 0) {
+            if (argc <= 0) {
                 log_diagnostic(LL_ERROR, "Expected a file name to be here to set a custom output file");
                 return false;
             }
@@ -31,6 +32,29 @@ bool parse_config(Config *conf, int argc, char **argv) {
             exit(0);
         } else if (strcmp(*argv, "-no-opt") == 0) {
             conf->dont_optimize = true;
+        } else if (strcmp(*argv, "-list-targets") == 0) {
+            log_diagnostic(LL_INFO, "linux_nasm");
+            log_diagnostic(LL_INFO, "windows_mingw");
+            exit(0);
+        } else if (strcmp(*argv, "-target") == 0) {
+            argc--;
+            argv++;
+            if (argc <= 0) {
+                log_diagnostic(LL_ERROR, "Expected a target name (run %s -list-targets)", conf->exe_name);
+                return false;
+            }
+            if (strcmp(*argv, "linux_nasm") == 0) {
+                conf->target = *argv;
+                argc--;
+                argv++;
+            } else if (strcmp(*argv, "windows_mingw")) {
+                conf->target = *argv;
+                argc--;
+                argv++;
+            } else {
+                log_diagnostic(LL_ERROR, "Unknown target name %s (run %s -list-targets)", *argv, conf->exe_name);
+                return false;
+            }
         } else {
             if (**argv == '-') {
                 log_diagnostic(LL_ERROR, "Unknown flag supplied");
@@ -66,8 +90,10 @@ void usage(char *program_name) {
     log_diagnostic(LL_INFO, "Usage: ");
     log_diagnostic(LL_INFO, "  %s <input.boa> [FLAGS]", program_name);
     log_diagnostic(LL_INFO, "  [FLAGS]:");
-    log_diagnostic(LL_INFO, "    -help          : Show this help message");
-    log_diagnostic(LL_INFO, "    -o             : Customize the output file name (format: -o <name>)");
-    log_diagnostic(LL_INFO, "    -keep-artifacts: Keep the build artifacts (.asm, .o files)");
-    log_diagnostic(LL_INFO, "    -no-opt        : Dont optimize the code");
+    log_diagnostic(LL_INFO, "    -help           : Show this help message");
+    log_diagnostic(LL_INFO, "    -o              : Customize the output file name (format: -o <name>)");
+    log_diagnostic(LL_INFO, "    -keep-artifacts : Keep the build artifacts (.asm, .o files)");
+    log_diagnostic(LL_INFO, "    -no-opt         : Dont optimize the code");
+    log_diagnostic(LL_INFO, "    -target <TARGET>: Select the target");
+    log_diagnostic(LL_INFO, "    -list-targets   : List available targets");
 }

--- a/src/config.h
+++ b/src/config.h
@@ -5,6 +5,7 @@ typedef struct {
     char *exe_name;
     char *input_name;
     char *output_name;
+    char *target;
     bool should_free_output_name;
     bool keep_build_artifacts;
     bool dont_optimize;

--- a/src/main.c
+++ b/src/main.c
@@ -33,9 +33,9 @@ int main(int argc, char **argv) {
     Target *t = NULL;
     if (c.target == NULL) {
         const char *target_name = target_enum_to_str(default_target);
-        t = find_target(target_name);
+        find_target(&t, target_name);
     } else {
-        t = find_target(c.target);
+        find_target(&t, c.target);
     }
 
     SourceFile file = {0};

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@
 
 #ifdef __unix__
 const TargetKind default_target = TK_Linux_x86_64_NASM;
-#elifdef _WIN32
+#elif defined(_WIN32)
 const TargetKind default_target = TK_Win_x86_64_MINGW;
 #endif
 
@@ -31,11 +31,13 @@ int main(int argc, char **argv) {
     }
 
     Target *t = NULL;
+    const char *target_name = (c.target == NULL) ? target_enum_to_str(default_target) : c.target;
     if (c.target == NULL) {
-        const char *target_name = target_enum_to_str(default_target);
-        find_target(&t, target_name);
-    } else {
-        find_target(&t, c.target);
+        if (!find_target(&t, target_name)) {
+            log_diagnostic(LL_ERROR, "Unknown target %s", c.target ? c.target : "(default)");
+            result = 1;
+            goto defer;
+        }
     }
 
     SourceFile file = {0};

--- a/src/main.c
+++ b/src/main.c
@@ -32,12 +32,10 @@ int main(int argc, char **argv) {
 
     Target *t = NULL;
     const char *target_name = (c.target == NULL) ? target_enum_to_str(default_target) : c.target;
-    if (c.target == NULL) {
-        if (!find_target(&t, target_name)) {
-            log_diagnostic(LL_ERROR, "Unknown target %s", c.target ? c.target : "(default)");
-            result = 1;
-            goto defer;
-        }
+    if (!find_target(&t, target_name)) {
+        log_diagnostic(LL_ERROR, "Unknown target %s", c.target ? c.target : "(default)");
+        result = 1;
+        goto defer;
     }
 
     SourceFile file = {0};

--- a/src/target.c
+++ b/src/target.c
@@ -1,11 +1,17 @@
 #include "target.h"
-#include "util.h"
+#include "backend/codegen/mingw_x86_64_windows.h"
 #include "backend/codegen/nasm_x86_64_linux.h"
+#include "util.h"
 
 static bool linux_nasm_gen(char *root_path, const SSAModule *mod);
 static bool linux_nasm_assemble(char *root_path);
 static bool linux_nasm_link(char *root_path);
 static void linux_nasm_cleanup(char *root_path);
+
+static bool windows_mingw_gen(char *root_path, const SSAModule *mod);
+static bool windows_mingw_assemble(char *root_path);
+static bool windows_mingw_link(char *root_path);
+static void windows_mingw_cleanup(char *root_path);
 
 static Target TARGET_LINUX_NASM = {
     .tk = TK_Linux_x86_64_NASM,
@@ -13,30 +19,120 @@ static Target TARGET_LINUX_NASM = {
     .generate = linux_nasm_gen,
     .assemble = linux_nasm_assemble,
     .link = linux_nasm_link,
-    .cleanup = linux_nasm_cleanup
+    .cleanup = linux_nasm_cleanup,
 };
 
-static Target* targets[] = {
-    &TARGET_LINUX_NASM,
-    NULL
+static Target TARGET_WINDOWS_MINGW = {
+    .tk = TK_Win_x86_64_MINGW,
+    .name = "windows_mingw",
+    .generate = windows_mingw_gen,
+    .assemble = windows_mingw_assemble,
+    .link = windows_mingw_link,
+    .cleanup = windows_mingw_cleanup,
 };
 
+static Target *targets[] = {&TARGET_LINUX_NASM, &TARGET_WINDOWS_MINGW, NULL};
 
-Target* find_target(const char* name) {
+Target *find_target(const char *name) {
     for (size_t i = 0; targets[i] != NULL; i++) {
         if (strcmp(targets[i]->name, name) == 0) return targets[i];
     }
     return NULL;
 }
 
-
-const char* target_enum_to_str(TargetKind kind) {
+const char *target_enum_to_str(TargetKind kind) {
     for (size_t i = 0; targets[i] != NULL; i++) {
         if (targets[i]->tk == kind) return targets[i]->name;
     }
     return NULL;
 }
 
+static bool windows_mingw_gen(char *root_path, const SSAModule *mod) {
+    Path p = path_from_cstr(root_path);
+    path_add_ext(&p, "s");
+    char *p_c = path_to_cstr(&p);
+    free(p.path.items);
+
+    FILE *f = fopen(p_c, "wb");
+    bool result = mingw_x86_64_windows_generate_file(f, mod);
+
+    fclose(f);
+    free(p_c);
+
+    return result;
+}
+
+static bool windows_mingw_assemble(char *root_path) {
+    Path p_asm = path_from_cstr(root_path);
+    Path p_o = path_from_cstr(root_path);
+
+    path_add_ext(&p_asm, "s");
+    char *p_asm_c = path_to_cstr(&p_asm);
+    free(p_asm.path.items);
+
+    path_add_ext(&p_o, "obj");
+    char *p_o_c = path_to_cstr(&p_o);
+    free(p_o.path.items);
+
+    if (run_program("x86_64-w64-mingw32-as", 3, (char *[]){p_asm_c, "-o", p_o_c, NULL}) != 0) {
+        log_diagnostic(LL_ERROR, "as failed");
+        free(p_asm_c);
+        free(p_o_c);
+        return false;
+    }
+    free(p_asm_c);
+    free(p_o_c);
+    return true;
+}
+static bool windows_mingw_link(char *root_path) {
+    Path p_o = path_from_cstr(root_path);
+    path_add_ext(&p_o, "obj");
+    char *p_o_c = path_to_cstr(&p_o);
+    free(p_o.path.items);
+
+    Path p_final = path_from_cstr(root_path);
+    path_add_ext(&p_o, "exe");
+    char *p_final_c = path_to_cstr(&p_final);
+    free(p_final.path.items);
+
+    // holy chunk
+    if (run_program("x86_64-w64-mingw32-gcc", 8,
+                    (char *[]){
+                        p_o_c,
+                        "-o",
+                        p_final_c,
+                        "-e",
+                        "_start",
+                        "-nostdlib",
+                        "-Wl,--subsystem=console",
+                        "-lkernel32",
+                        NULL,
+                    }) != 0) {
+        log_diagnostic(LL_ERROR, "ld failed");
+        free(p_o_c);
+        free(p_final_c);
+        return false;
+    }
+
+    free(p_final_c);
+    return true;
+}
+static void windows_mingw_cleanup(char *root_path) {
+    Path p_s = path_from_cstr(root_path);
+    Path p_obj = path_from_cstr(root_path);
+
+    path_add_ext(&p_s, "s");
+    char *p_s_c = path_to_cstr(&p_s);
+    free(p_s.path.items);
+
+    path_add_ext(&p_obj, "obj");
+    char *p_obj_c = path_to_cstr(&p_obj);
+    free(p_obj.path.items);
+
+    run_program("del", 2, (char *[]){p_obj_c, p_s_c, NULL});
+    free(p_obj_c);
+    free(p_s_c);
+}
 
 static bool linux_nasm_gen(char *root_path, const SSAModule *mod) {
     Path p = path_from_cstr(root_path);
@@ -71,6 +167,8 @@ static bool linux_nasm_assemble(char *root_path) {
         free(p_o_c);
         return false;
     }
+    free(p_asm_c);
+    free(p_o_c);
     return true;
 }
 

--- a/src/target.c
+++ b/src/target.c
@@ -1,0 +1,108 @@
+#include "target.h"
+#include "util.h"
+#include "backend/codegen/nasm_x86_64_linux.h"
+
+static bool linux_nasm_gen(char *root_path, const SSAModule *mod);
+static bool linux_nasm_assemble(char *root_path);
+static bool linux_nasm_link(char *root_path);
+static void linux_nasm_cleanup(char *root_path);
+
+static Target TARGET_LINUX_NASM = {
+    .tk = TK_Linux_x86_64_NASM,
+    .name = "linux_nasm",
+    .generate = linux_nasm_gen,
+    .assemble = linux_nasm_assemble,
+    .link = linux_nasm_link,
+    .cleanup = linux_nasm_cleanup
+};
+
+static Target* targets[] = {
+    &TARGET_LINUX_NASM,
+    NULL
+};
+
+
+Target* find_target(const char* name) {
+    for (size_t i = 0; targets[i] != NULL; i++) {
+        if (strcmp(targets[i]->name, name) == 0) return targets[i];
+    }
+    return NULL;
+}
+
+
+const char* target_enum_to_str(TargetKind kind) {
+    for (size_t i = 0; targets[i] != NULL; i++) {
+        if (targets[i]->tk == kind) return targets[i]->name;
+    }
+    return NULL;
+}
+
+
+static bool linux_nasm_gen(char *root_path, const SSAModule *mod) {
+    Path p = path_from_cstr(root_path);
+    path_add_ext(&p, "asm");
+    char *p_c = path_to_cstr(&p);
+    free(p.path.items);
+
+    FILE *f = fopen(p_c, "wb");
+    bool result = nasm_x86_64_linux_generate_file(f, mod);
+
+    fclose(f);
+    free(p_c);
+
+    return result;
+}
+
+static bool linux_nasm_assemble(char *root_path) {
+    Path p_asm = path_from_cstr(root_path);
+    Path p_o = path_from_cstr(root_path);
+
+    path_add_ext(&p_asm, "asm");
+    char *p_asm_c = path_to_cstr(&p_asm);
+    free(p_asm.path.items);
+
+    path_add_ext(&p_o, "o");
+    char *p_o_c = path_to_cstr(&p_o);
+    free(p_o.path.items);
+
+    if (run_program("nasm", 5, (char *[]){p_asm_c, "-f", "elf64", "-o", p_o_c, NULL}) != 0) {
+        log_diagnostic(LL_ERROR, "nasm failed");
+        free(p_asm_c);
+        free(p_o_c);
+        return false;
+    }
+    return true;
+}
+
+static bool linux_nasm_link(char *root_path) {
+    Path p_o = path_from_cstr(root_path);
+    path_add_ext(&p_o, "o");
+    char *p_o_c = path_to_cstr(&p_o);
+    free(p_o.path.items);
+
+    if (run_program("ld", 3, (char *[]){p_o_c, "-o", root_path, NULL}) != 0) {
+        log_diagnostic(LL_ERROR, "ld failed");
+        free(p_o_c);
+        return false;
+    }
+
+    free(p_o_c);
+    return true;
+}
+
+static void linux_nasm_cleanup(char *root_path) {
+    Path p_asm = path_from_cstr(root_path);
+    Path p_o = path_from_cstr(root_path);
+
+    path_add_ext(&p_asm, "asm");
+    char *p_asm_c = path_to_cstr(&p_asm);
+    free(p_asm.path.items);
+
+    path_add_ext(&p_o, "o");
+    char *p_o_c = path_to_cstr(&p_o);
+    free(p_o.path.items);
+
+    run_program("rm", 2, (char *[]){p_o_c, p_asm_c, NULL});
+    free(p_o_c);
+    free(p_asm_c);
+}

--- a/src/target.c
+++ b/src/target.c
@@ -95,7 +95,7 @@ static bool windows_mingw_link(char *root_path) {
     free(p_o.path.items);
 
     Path p_final = path_from_cstr(root_path);
-    path_add_ext(&p_o, "exe");
+    path_add_ext(&p_final, "exe");
     char *p_final_c = path_to_cstr(&p_final);
     free(p_final.path.items);
 
@@ -111,12 +111,13 @@ static bool windows_mingw_link(char *root_path) {
                         "-lkernel32",
                         NULL,
                     }) != 0) {
-        log_diagnostic(LL_ERROR, "ld failed");
+        log_diagnostic(LL_ERROR, "linking failed failed");
         free(p_o_c);
         free(p_final_c);
         return false;
     }
 
+    free(p_o_c);
     free(p_final_c);
     return true;
 }
@@ -132,7 +133,8 @@ static void windows_mingw_cleanup(char *root_path) {
     char *p_obj_c = path_to_cstr(&p_obj);
     free(p_obj.path.items);
 
-    run_program("del", 2, (char *[]){p_obj_c, p_s_c, NULL});
+    remove(p_obj_c);
+    remove(p_s_c);
     free(p_obj_c);
     free(p_s_c);
 }

--- a/src/target.c
+++ b/src/target.c
@@ -2,6 +2,7 @@
 #include "backend/codegen/mingw_x86_64_windows.h"
 #include "backend/codegen/nasm_x86_64_linux.h"
 #include "util.h"
+#include <stdio.h>
 
 static bool linux_nasm_gen(char *root_path, const SSAModule *mod);
 static bool linux_nasm_assemble(char *root_path);
@@ -99,13 +100,12 @@ static bool windows_mingw_link(char *root_path) {
     free(p_final.path.items);
 
     // holy chunk
-    if (run_program("x86_64-w64-mingw32-gcc", 8,
+    if (run_program("x86_64-w64-mingw32-gcc", 7,
                     (char *[]){
                         p_o_c,
                         "-o",
                         p_final_c,
-                        "-e",
-                        "_start",
+                        "-Wl,-e,_start",
                         "-nostdlib",
                         "-Wl,--subsystem=console",
                         "-lkernel32",
@@ -203,7 +203,8 @@ static void linux_nasm_cleanup(char *root_path) {
     char *p_o_c = path_to_cstr(&p_o);
     free(p_o.path.items);
 
-    run_program("rm", 2, (char *[]){p_o_c, p_asm_c, NULL});
+    remove(p_o_c);
+    remove(p_asm_c);
     free(p_o_c);
     free(p_asm_c);
 }

--- a/src/target.c
+++ b/src/target.c
@@ -33,11 +33,14 @@ static Target TARGET_WINDOWS_MINGW = {
 
 static Target *targets[] = {&TARGET_LINUX_NASM, &TARGET_WINDOWS_MINGW, NULL};
 
-Target *find_target(const char *name) {
+bool find_target(Target** out, const char* name) {
     for (size_t i = 0; targets[i] != NULL; i++) {
-        if (strcmp(targets[i]->name, name) == 0) return targets[i];
+        if (strcmp(targets[i]->name, name) == 0) {
+            *out = targets[i];
+            return true;
+        }
     }
-    return NULL;
+    return false;
 }
 
 const char *target_enum_to_str(TargetKind kind) {

--- a/src/target.h
+++ b/src/target.h
@@ -3,6 +3,7 @@
 typedef enum {
     TK_Linux_x86_64_NASM,
     TK_Win_x86_64_MINGW,
+    TK_Count,
 } TargetKind;
 
 typedef struct {
@@ -14,7 +15,7 @@ typedef struct {
     void (*cleanup)(char *root_path);
 } Target;
 
-Target* find_target(const char* name);
+bool find_target(Target** out, const char* name);
 const char* target_enum_to_str(TargetKind kind);
 
 

--- a/src/target.h
+++ b/src/target.h
@@ -1,0 +1,20 @@
+#include "backend/ir/ssa.h"
+
+typedef enum {
+    TK_Linux_x86_64_NASM,
+    TK_Win_x86_64_MINGW,
+} TargetKind;
+
+typedef struct {
+    const char *name;
+    TargetKind tk;
+    bool (*generate)(char *root_path, const SSAModule *mod);
+    bool (*assemble)(char *root_path);
+    bool (*link)(char *root_path);
+    void (*cleanup)(char *root_path);
+} Target;
+
+Target* find_target(const char* name);
+const char* target_enum_to_str(TargetKind kind);
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Windows (MinGW) target; build Windows executables.
  - Target selection via -list-targets and -target <name>; sensible OS defaults applied when unspecified.
- Bug Fixes
  - Corrected -o option parsing to accept the provided filename.
- Documentation
  - Updated help/usage to include new target flags.
  - README now demonstrates invoking with -help and lists supported targets (Windows via MinGW, Linux via NASM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->